### PR TITLE
Fix bugs in derive implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ default = ["regex", "use_logging"]
 unstable = []
 use_logging = ["log", "env_logger"]
 regex = ["env_logger/regex"]
+derive = ["quickcheck_derive"]
 
 [lib]
 name = "quickcheck"
@@ -29,3 +30,4 @@ env_logger = { version = "0.5", default-features = false, optional = true }
 log = { version = "0.4", optional = true }
 rand = "0.6.3"
 rand_core = "0.3.0"
+quickcheck_derive = { path = "quickcheck_derive", version = "0.1.2", optional = true }

--- a/quickcheck_derive/Cargo.toml
+++ b/quickcheck_derive/Cargo.toml
@@ -12,7 +12,6 @@ version = "0.1.2"
 [dependencies]
 quote = "^0.3.15"
 syn = "^0.11.11"
-rand = "0.5"
 
 [dev-dependencies.quickcheck]
 path = ".."

--- a/quickcheck_derive/Cargo.toml
+++ b/quickcheck_derive/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-authors = ["Nathaniel Ringo <remexre@gmail.com>"]
+authors = [
+  "Nathaniel Ringo <remexre@gmail.com>",
+  "Felix Chapman <aelred717@gmail.com>",
+  "Michael Howell <michael@notriddle.com>"
+]
 description = "#[derive(Arbitrary, Clone)]"
 license = "MIT"
 name = "quickcheck_derive"

--- a/quickcheck_derive/src/structural.rs
+++ b/quickcheck_derive/src/structural.rs
@@ -22,11 +22,16 @@ pub fn derive_struct(item: &DeriveInput, variant: &VariantData) -> (Tokens, Toke
                 },
                 length if length > 8 => {
                     (
-                        quote!(tuplify!(#(self.#field_names),*)),
+                        quote!({let k = self.clone(); tuplify!(#(k.#field_names),*)}),
                         quote!(tuplify_pattern!(#(#alphas),*))
                     )
                 },
-                _ => (quote!((#(self.#field_names),*)), quote!((#(#alphas),*))),
+                _ => {
+                    (
+                        quote!({let k = self.clone(); (#(k.#field_names),*)}),
+                        quote!((#(#alphas),*))
+                    )
+                },
             };
 
             quote! {

--- a/quickcheck_derive/src/structural.rs
+++ b/quickcheck_derive/src/structural.rs
@@ -82,8 +82,7 @@ pub fn derive_enum(item: &DeriveInput, variants: &[Variant]) -> (Tokens, Tokens)
     let shrink_variants = variants.iter().map(|v| enum_shrink_variant(name, v));
 
     let arbitrary = quote! {
-        extern crate rand;
-        match rand::Rng::gen_range(_g, 0, #variant_count) {
+        match ::quickcheck::Rng::gen_range(_g, 0, #variant_count) {
             #(#arbitrary_variants,)*
             _ => unreachable!(),
         }

--- a/quickcheck_derive/tests/move_type.rs
+++ b/quickcheck_derive/tests/move_type.rs
@@ -1,0 +1,52 @@
+#[macro_use]
+extern crate quickcheck;
+#[macro_use]
+extern crate quickcheck_derive;
+
+// Based on code in rust-content-security-policy
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq)]
+#[arbitrary(constraint = "self.is_valid()")]
+pub struct Directive {
+    name: String,
+    value: Vec<String>,
+}
+
+impl Directive {
+    pub fn is_valid(&self) -> bool {
+        true
+    }
+}
+
+quickcheck! {
+    fn struct_constraint(t: Directive) -> bool {
+        t.is_valid()
+    }
+}
+
+// Since there's different code triggered for length > 8
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq)]
+#[arbitrary(constraint = "self.is_valid()")]
+pub struct GiantDirective {
+    v1: String,
+    v2: String,
+    v3: String,
+    v4: String,
+    v5: String,
+    v6: String,
+    v7: String,
+    v8: String,
+    v9: String,
+    v10: String,
+}
+
+impl GiantDirective {
+    pub fn is_valid(&self) -> bool {
+        true
+    }
+}
+
+quickcheck! {
+    fn struct_constraint_giant(t: GiantDirective) -> bool {
+        t.is_valid()
+    }
+}

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -22,6 +22,9 @@ use std::time::{UNIX_EPOCH, Duration, SystemTime};
 use rand::{self, Rng, RngCore};
 use rand::seq::SliceRandom;
 
+#[cfg(feature = "derive")]
+pub use quickcheck_derive::Arbitrary;
+
 /// `Gen` wraps a `rand::RngCore` with parameters to control the distribution of
 /// random values.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ extern crate env_logger;
 extern crate log;
 extern crate rand;
 extern crate rand_core;
+#[cfg(feature = "derive")]
+extern crate quickcheck_derive;
 
 pub use arbitrary::{
     Arbitrary, Gen, StdGen, StdThreadGen,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,8 @@ pub use arbitrary::{
     Arbitrary, Gen, StdGen, StdThreadGen,
     empty_shrinker, single_shrinker,
 };
-pub use rand_core::RngCore;
+pub use rand::RngCore;
+pub use rand::Rng;
 pub use tester::{QuickCheck, Testable, TestResult, quickcheck};
 
 /// A macro for writing quickcheck tests.


### PR DESCRIPTION
* Avoid adding `extern crate rand` declarations in expanded code. Doing that requires the crate you're expanding into have the `rand` crate as a dependency, which we should not require. Instead, the necessary `Rand` trait is re-exported through the `quickcheck` crate, which we can safely assume the consumer uses.

* Don't just expand into `(self.a, self.b, self.c).shrink()`. That produces borrowck errors when the struct members aren't `Copy`. Instead, clone `self` and then do it.

* Add a `derive` feature to the main `quickcheck` crate, and re-export the `Arbitrary` derive macro alongside the `Arbitrary` struct. This is basically copying what `serde` does, and it allows the user to just write this:

```toml
[dependencies]
quickcheck = { features = ["derive"], version = "TBD", optional = true }
```

```rust
#[cfg(feature = "quickcheck")]
use quickcheck::Arbitrary;

#[cfg_attr(feature = "quickcheck", derive(Arbitrary)]
struct Directive {
    name: String,
    value: Vec<String>,
}
```

Which is pretty much the UX we want.